### PR TITLE
Code Clean-up and "r" calculation changes

### DIFF
--- a/second.cpp
+++ b/second.cpp
@@ -19,8 +19,8 @@ void goAndUse(char *x, char *y, int t)
 	}
 }
 
- int r = 12  - 10;
- 
+int r = 12 - 1;
+
 void memoryLeak()
 {
 	// null pointer dereference - malloc may fail
@@ -29,7 +29,5 @@ void memoryLeak()
 	// buffer overrun - ptr not large enough for string copy
 	strcpy(ptr, "Scirs Ltd");
 	
-	goAndUse(ptr, ptr, 10);	
+	goAndUse(ptr, ptr, 10);
 }
-		
-

--- a/second.cpp
+++ b/second.cpp
@@ -19,7 +19,7 @@ void goAndUse(char *x, char *y, int t)
 	}
 }
 
- int r = 12  - 2;
+ int r = 12  - 10;
  
 void memoryLeak()
 {


### PR DESCRIPTION
Removed annoying and redundant white spaces.

Change calculation of "r" variable to be "12-1" rather than "12-2".